### PR TITLE
Verify Webhook Signature

### DIFF
--- a/server/gitpwnd/__init__.py
+++ b/server/gitpwnd/__init__.py
@@ -13,6 +13,7 @@ with open("server_creds.yml", 'r') as f:
 
 app.config['BASIC_AUTH_USERNAME'] = server_config["basic_auth_username"]
 app.config['BASIC_AUTH_PASSWORD'] = server_config["basic_auth_password"]
+app.config['HOOK_SECRET'] = server_config["hook_secret"]
 
 # TODO: fix the naming confusion. This is the path to a local version of the repo
 # we're using for command and control

--- a/server/gitpwnd/util/crypto_helper.py
+++ b/server/gitpwnd/util/crypto_helper.py
@@ -5,6 +5,7 @@ from gitpwnd import app
 
 class CryptoHelper:
 
+    @staticmethod
     def verify_signature(payload, secret):
         key = app.config["HOOK_SECRET"].encode('utf-8')
         h = hmac.new(key, digestmod=hashlib.sha1)

--- a/server/gitpwnd/util/crypto_helper.py
+++ b/server/gitpwnd/util/crypto_helper.py
@@ -1,0 +1,14 @@
+import hmac
+import hashlib
+
+from gitpwnd import app
+
+class CryptoHelper:
+
+    def verify_signature(payload, secret):
+        key = app.config["HOOK_SECRET"].encode('utf-8')
+        h = hmac.new(key, digestmod=hashlib.sha1)
+        h.update(payload.encode('utf-8'))
+        signature = "sha1=" + h.hexdigest()
+
+        return hmac.compare_digest(signature, secret):

--- a/server/server_creds.yml.template
+++ b/server/server_creds.yml.template
@@ -1,3 +1,4 @@
 basic_auth_username: "gitpwnd"
 basic_auth_password: "$basic_auth_password"
 benign_repo_path: "$benign_repo_path"
+hook_secret: "$hook_secret"


### PR DESCRIPTION
These changes:
- enforce a secret associated with the webhook
- allow the server to validate that the payload is coming from Github before continuing processing